### PR TITLE
fix compilation errors in calls to `write_tag` and in ugawg_hsc.cpp

### DIFF
--- a/src/Omega_h_vtk.cpp
+++ b/src/Omega_h_vtk.cpp
@@ -872,13 +872,13 @@ void write_vtu(filesystem::path const& filename, Mesh* mesh, Topo_type max_type,
   stream << "</Points>\n";
   stream << "<PointData>\n";
   if (mesh->has_tag(VERT, "global") && tags[VERT].count("global")) {
-    write_tag(stream, mesh->get_tag<GO>(VERT, "global"), mesh->dim(), compress);
+    write_tag(stream, mesh->get_tag<GO>(VERT, "global"), mesh->dim(), 0, mesh, compress);
   }
   for (Int i = 0; i < mesh->ntags(Topo_type::vertex); ++i) {
     auto tag = mesh->get_tag(Topo_type::vertex, i);
     if (tag->name() != "coordinates" && tag->name() != "global" &&
         tags[VERT].count(tag->name())) {
-      write_tag(stream, tag, mesh->dim(), compress);
+      write_tag(stream, tag, mesh->dim(), 0, mesh, compress);
     }
   }
   stream << "</PointData>\n";
@@ -886,7 +886,7 @@ void write_vtu(filesystem::path const& filename, Mesh* mesh, Topo_type max_type,
   if (mesh->has_tag(cell_dim, "global") &&
       tags[size_t(cell_dim)].count("global")) {
     write_tag(
-        stream, mesh->get_tag<GO>(cell_dim, "global"), mesh->dim(), compress);
+        stream, mesh->get_tag<GO>(cell_dim, "global"), mesh->dim(), cell_dim, mesh, compress);
   }
   if (tags[size_t(cell_dim)].count("vtkGhostType")) {
     write_vtk_ghost_types(stream, mesh, cell_dim, compress);
@@ -895,28 +895,28 @@ void write_vtu(filesystem::path const& filename, Mesh* mesh, Topo_type max_type,
     for (Int i = 0; i < mesh->ntags(Topo_type::tetrahedron); ++i) {
       auto tag = mesh->get_tag(Topo_type::tetrahedron, i);
       if (tag->name() != "global" && tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, mesh, compress);
       }
     }
 
     for (Int i = 0; i < mesh->ntags(Topo_type::hexahedron); ++i) {
       auto tag = mesh->get_tag(Topo_type::hexahedron, i);
       if (tag->name() != "global" && tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, mesh, compress);
       }
     }
 
     for (Int i = 0; i < mesh->ntags(Topo_type::wedge); ++i) {
       auto tag = mesh->get_tag(Topo_type::wedge, i);
       if (tag->name() != "global" && tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, mesh, compress);
       }
     }
 
     for (Int i = 0; i < mesh->ntags(Topo_type::pyramid); ++i) {
       auto tag = mesh->get_tag(Topo_type::pyramid, i);
       if (tag->name() != "global" && tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, mesh, compress);
       }
     }
   }
@@ -924,14 +924,14 @@ void write_vtu(filesystem::path const& filename, Mesh* mesh, Topo_type max_type,
     for (Int i = 0; i < mesh->ntags(Topo_type::triangle); ++i) {
       auto tag = mesh->get_tag(Topo_type::triangle, i);
       if (tag->name() != "global" && tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, mesh, compress);
       }
     }
 
     for (Int i = 0; i < mesh->ntags(Topo_type::quadrilateral); ++i) {
       auto tag = mesh->get_tag(Topo_type::quadrilateral, i);
       if (tag->name() != "global" && tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, mesh, compress);
       }
     }
   }
@@ -939,7 +939,7 @@ void write_vtu(filesystem::path const& filename, Mesh* mesh, Topo_type max_type,
     for (Int i = 0; i < mesh->ntags(cell_dim); ++i) {
       auto tag = mesh->get_tag(cell_dim, i);
       if (tag->name() != "global" && tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, mesh, compress);
       }
     }
   }

--- a/src/ugawg_hsc.cpp
+++ b/src/ugawg_hsc.cpp
@@ -63,21 +63,21 @@ int main(int argc, char** argv) {
   auto reg_boundary_ids = (mesh.ask_revClass(3)).ab2b;
   auto nbreg = reg_boundary_ids.size();
 
-  mesh.add_boundaryField<LO>(0, "field", 1);
-  Write<LO> valsr_v(nbvert, 100);
-  mesh.set_boundaryField_array(0, "field", Read<LO>(valsr_v));
-  Write<Real> vals_real(nbvert, 50.2523232);
-  mesh.add_boundaryField<Real>(0, "field1", 1, Read<Real>(vals_real));
-  mesh.add_boundaryField<LO>(1, "field", 1);
-  Write<LO> vals(nbedge, 100);
-  Read<LO> vals_r(vals);
+  mesh.add_boundaryField<Omega_h::LO>(0, "field", 1);
+  Omega_h::Write<Omega_h::LO> valsr_v(nbvert, 100);
+  mesh.set_boundaryField_array(0, "field", Omega_h::Read<Omega_h::LO>(valsr_v));
+  Omega_h::Write<Omega_h::Real> vals_real(nbvert, 50.2523232);
+  mesh.add_boundaryField<Omega_h::Real>(0, "field1", 1, Omega_h::Read<Omega_h::Real>(vals_real));
+  mesh.add_boundaryField<Omega_h::LO>(1, "field", 1);
+  Omega_h::Write<Omega_h::LO> vals(nbedge, 100);
+  Omega_h::Read<Omega_h::LO> vals_r(vals);
   mesh.set_boundaryField_array(1, "field", vals_r);
-  mesh.add_boundaryField<LO>(2, "field", 1);
-  Write<LO> valsf(nbface, 12);
-  mesh.set_boundaryField_array(2, "field", Read<LO>(valsf));
-  mesh.add_boundaryField<LO>(3, "field", 1);
-  Write<LO> valsr(nbreg, 100);
-  Read<LO> valsr_r(valsr);
+  mesh.add_boundaryField<Omega_h::LO>(2, "field", 1);
+  Omega_h::Write<Omega_h::LO> valsf(nbface, 12);
+  mesh.set_boundaryField_array(2, "field", Omega_h::Read<Omega_h::LO>(valsf));
+  mesh.add_boundaryField<Omega_h::LO>(3, "field", 1);
+  Omega_h::Write<Omega_h::LO> valsr(nbreg, 100);
+  Omega_h::Read<Omega_h::LO> valsr_r(valsr);
   mesh.set_boundaryField_array(3, "field", valsr_r);
 
   add_boundaryField_transferMap(&opts, "field", OMEGA_H_INHERIT);


### PR DESCRIPTION
Fixes compilation errors due to missing `write_tag` arguments and missing scope in ugawg_hsc.cpp.

I only built `ugawg_hsc`; there may be other call paths that still produce compilation errors associated with the `write_tag` call.